### PR TITLE
Retweet fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'org.springframework.boot'
 
 jar {
     baseName = 'jivecampaign'
-    version = '0.4.0'
+    version = '0.4.1'
 }
 
 repositories {

--- a/src/main/java/co/uk/jiveelection/campaign/output/twitter/TwitterOutput.java
+++ b/src/main/java/co/uk/jiveelection/campaign/output/twitter/TwitterOutput.java
@@ -148,7 +148,9 @@ public class TwitterOutput implements Output {
             @Override
             public void onStatus(Status status) {
                 if (status.getUser().getId() == realId) {
-                    onStatusReceived(status);
+                    if (!status.isRetweet()) {
+                        onStatusReceived(status);
+                    }
                 }
             }
 

--- a/src/main/java/co/uk/jiveelection/campaign/output/twitter/TwitterOutput.java
+++ b/src/main/java/co/uk/jiveelection/campaign/output/twitter/TwitterOutput.java
@@ -131,7 +131,7 @@ public class TwitterOutput implements Output {
     /**
      * Initialises a filter for the real Twitter user than is to be Jive translated.
      *
-     * @throws TwitterException
+     * @throws TwitterException when Twitter service or network is unavailable
      */
     public void init() throws TwitterException {
         long realId = twitter.showUser(realUserName).getId();
@@ -180,7 +180,7 @@ public class TwitterOutput implements Output {
     @Override
     public void outputJive(String jive) {
         try {
-            Status status = twitter.updateStatus(jive);
+            twitter.updateStatus(jive);
         } catch (TwitterException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
Prevent retweets. The quoted tweet is inaccessible and we only get a small summary in the status so it doesn't make sense to continue to try and translate it.